### PR TITLE
feat: add loan type

### DIFF
--- a/src/app/[...slug]/components/LoanSelectDropdown.tsx
+++ b/src/app/[...slug]/components/LoanSelectDropdown.tsx
@@ -1,5 +1,6 @@
 import { useBendystrawQuery } from "@/graphql/useBendystrawQuery";
 import { LoansDetailsByAccountDocument } from "@/generated/graphql";
+import type { Loan } from "@/types/loan";
 
 export function LoanSelectDropdown({
   revnetId,
@@ -12,17 +13,7 @@ export function LoanSelectDropdown({
   address: string;
   selectedLoanId: string | null;
   setSelectedLoanId: (id: string) => void;
-  onLoanSelected?: (loan: {
-    id: string;
-    borrowAmount: string;
-    collateral: string;
-    prepaidDuration: number;
-    createdAt: number;
-    projectId: number;
-    terminal: string;
-    token: string;
-    chainId: number;
-  }) => void;
+  onLoanSelected?: (loan: Loan) => void;
 }) {
   const { data } = useBendystrawQuery(LoansDetailsByAccountDocument, {
     owner: address,

--- a/src/app/[...slug]/components/LoansDetailsTable.tsx
+++ b/src/app/[...slug]/components/LoansDetailsTable.tsx
@@ -19,6 +19,7 @@ import {
 import { ChainLogo } from "@/components/ChainLogo";
 import { Button } from "@/components/ui/button";
 import { useProjectBaseToken } from "@/hooks/useProjectBaseToken";
+import type { Loan } from "@/types/loan";
 
 // Constants for loan calculations and display
 const LOAN_CONSTANTS = {
@@ -41,13 +42,13 @@ function LoanRow({
   onReallocateLoan,
   suckerGroupData
 }: {
-  loan: any;
+  loan: Loan;
   revnetId: bigint;
   tokenSymbol: string;
   selectedLoanId?: string;
   now: number;
   onSelectLoan?: (loanId: string, chainId: number) => void;
-  onReallocateLoan?: (loan: any) => void;
+  onReallocateLoan?: (loan: Loan) => void;
   suckerGroupData?: any;
 }) {
   const { token } = useJBTokenContext();
@@ -147,7 +148,7 @@ export function LoanDetailsTable({
   revnetId: bigint;
   address: string;
   onSelectLoan?: (loanId: string, chainId: number) => void;
-  onReallocateLoan?: (loan: any) => void;
+  onReallocateLoan?: (loan: Loan) => void;
   chainId?: number;
   tokenSymbol: string;
   title?: string;

--- a/src/app/[...slug]/components/UserTokenBalanceCard/AdditionalCollateralSection.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/AdditionalCollateralSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LoanDetailsTable } from "../LoansDetailsTable";
+import type { Loan } from "@/types/loan";
 
 export function AdditionalCollateralSection({
   projectId,
@@ -13,7 +14,7 @@ export function AdditionalCollateralSection({
   projectId: number;
   address: string;
   cashOutChainId: number;
-  setSelectedLoan: (loan: any) => void;
+  setSelectedLoan: (loan: Loan) => void;
   borrowedEth?: string;
   tokenSymbol: string;
 }) {
@@ -25,7 +26,7 @@ export function AdditionalCollateralSection({
         address={address}
         chainId={cashOutChainId}
         tokenSymbol={tokenSymbol}
-        onSelectLoan={(loanId, loanData) => setSelectedLoan(loanData)}
+        onReallocateLoan={setSelectedLoan}
       />
       {borrowedEth && <p>Borrowed (wei): {borrowedEth}</p>}
     </div>

--- a/src/app/[...slug]/components/UserTokenBalanceCard/BorrowDialog.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/BorrowDialog.tsx
@@ -17,6 +17,7 @@ import { SimulatedLoanCard } from "../SimulatedLoanCard";
 import { LoanFeeChart } from "../LoanFeeChart";
 import { ImportantInfo } from "./ImportantInfo";
 import { useBorrowDialogState } from "./hooks/useBorrowDialogState";
+import type { Loan } from "@/types/loan";
 import { useEffect, useCallback } from "react";
 import { ChainLogo } from "@/components/ChainLogo";
 import { JB_CHAINS } from "juice-sdk-core";
@@ -39,7 +40,7 @@ export function BorrowDialog({
 }: PropsWithChildren<{
   projectId: bigint;
   tokenSymbol: string;
-  selectedLoan?: any;
+  selectedLoan?: Loan;
 }>) {
   
   const borrowDialog = useBorrowDialogState({

--- a/src/app/[...slug]/components/UserTokenBalanceCard/ReallocateDialog.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/ReallocateDialog.tsx
@@ -17,6 +17,7 @@ import { LoanFeeChart } from "../LoanFeeChart";
 import { ImportantInfo } from "./ImportantInfo";
 import { useBorrowDialogState } from "./hooks/useBorrowDialogState";
 import { SimulatedLoanCard } from "../SimulatedLoanCard";
+import type { Loan } from "@/types/loan";
 
 import { BorrowState, borrowStatusMessages } from "./constants/borrowStatus";
 
@@ -30,7 +31,7 @@ export function ReallocateDialog({
 }: {
   projectId: bigint;
   tokenSymbol: string;
-  selectedLoan: any;
+  selectedLoan: Loan;
   children: React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;

--- a/src/app/[...slug]/components/UserTokenBalanceCard/UserTokenBalanceCard.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/UserTokenBalanceCard.tsx
@@ -14,6 +14,7 @@ import { BorrowDialog } from "./BorrowDialog";
 import { ReallocateDialog } from "./ReallocateDialog";
 import { RepayDialog } from "./RepayDialog";
 import { LoanDetailsTable } from "../LoansDetailsTable";
+import type { Loan } from "@/types/loan";
 import { useAccount } from "wagmi";
 import { useBendystrawQuery } from "@/graphql/useBendystrawQuery";
 import { ProjectDocument, SuckerGroupDocument } from "@/generated/graphql";
@@ -82,7 +83,7 @@ export function UserTokenBalanceCard() {
   const [selectedChainId, setSelectedChainId] = useState<number | null>(null);
   const [showRepayDialog, setShowRepayDialog] = useState(false);
   const borrowDialogTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const [reallocateLoan, setReallocateLoan] = useState<any>(null);
+  const [reallocateLoan, setReallocateLoan] = useState<Loan | null>(null);
   const [showReallocateDialog, setShowReallocateDialog] = useState(false);
 
   return (

--- a/src/app/[...slug]/components/UserTokenBalanceCard/hooks/useBorrowDialogState.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/hooks/useBorrowDialogState.tsx
@@ -36,6 +36,7 @@ import { USDC_ADDRESSES } from "@/app/constants";
 import { getTokenSymbolFromAddress, createTokenConfigGetter } from "@/lib/tokenUtils";
 
 import { BorrowState } from "../constants/borrowStatus";
+import type { Loan } from "@/types/loan";
 
 
 // Types
@@ -45,7 +46,7 @@ type RepayState = "idle" | "waiting-signature" | "pending" | "success" | "error"
 interface UseBorrowDialogProps {
   projectId: bigint;
   tokenSymbol: string;
-  selectedLoan?: any;
+  selectedLoan?: Loan;
   defaultTab?: "borrow" | "repay";
 }
 
@@ -76,7 +77,7 @@ export function useBorrowDialogState({
   const [prepaidPercent, setPrepaidPercent] = useState("2.5");
   const [nativeToWallet, setNativeToWallet] = useState(0);
   const [grossBorrowedNative, setGrossBorrowedNative] = useState(0);
-  const [internalSelectedLoan, setInternalSelectedLoan] = useState<any | null>(selectedLoan ?? null);
+  const [internalSelectedLoan, setInternalSelectedLoan] = useState<Loan | null>(selectedLoan ?? null);
 
   // Repay-related state
   const [repayStatus, setRepayStatus] = useState<RepayState>("idle");
@@ -413,7 +414,7 @@ export function useBorrowDialogState({
     setInternalSelectedLoan(null);
   }, [balances, projectTokenDecimals]);
 
-  const handleLoanSelection = useCallback((loanId: string, loanData: any) => {
+  const handleLoanSelection = useCallback((loanId: string, loanData: Loan) => {
     setInternalSelectedLoan(loanData);
     // Set the cashOutChainId based on the loan's chain
     if (loanData?.chainId) {

--- a/src/types/loan.ts
+++ b/src/types/loan.ts
@@ -1,0 +1,11 @@
+export interface Loan {
+  borrowAmount: string;
+  collateral: string;
+  prepaidDuration: number;
+  projectId: number;
+  terminal: string;
+  token: string;
+  chainId: number;
+  createdAt: number;
+  id: string;
+}


### PR DESCRIPTION
## Summary
- define Loan interface for loan data fields
- use Loan type across borrow and reallocate flows
- store reallocate loan state as `Loan | null`

## Testing
- `yarn --ignore-engines ts:compile` *(fails: Cannot find module 'juice-sdk-core' and other dependencies)*
- `yarn --ignore-engines install` *(fails: tunneling socket could not be established, statusCode=403)*

------
https://chatgpt.com/codex/tasks/task_e_68938262cf44832e99e7069090e67031