### PR TITLE
refactor: extract collateral input

### DIFF
--- a/src/app/[...slug]/components/UserTokenBalanceCard/BorrowDialog.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/BorrowDialog.tsx
@@ -1,6 +1,4 @@
 import { PropsWithChildren } from "react";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
 import { formatUnits } from "viem";
 import { NATIVE_TOKEN_DECIMALS, JBChainId } from "juice-sdk-core";
 import {
@@ -19,16 +17,9 @@ import { ImportantInfo } from "./ImportantInfo";
 import { useBorrowDialogState } from "./hooks/useBorrowDialogState";
 import type { Loan } from "@/types/loan";
 import { useEffect, useCallback } from "react";
-import { ChainLogo } from "@/components/ChainLogo";
 import { JB_CHAINS } from "juice-sdk-core";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { USDC_ADDRESSES } from "@/app/constants";
+import { CollateralInput } from "./CollateralInput";
 
 import { BorrowState, borrowStatusMessages } from "./constants/borrowStatus";
 
@@ -154,140 +145,16 @@ export function BorrowDialog({
             </div>
           </div>
 
-          {/* Collateral Input Section - Like RedeemDialog */}
-          <div className="grid w-full gap-1.5">
-            <Label htmlFor="collateral-amount" className="text-zinc-900">
-              How much {tokenSymbol} do you want to collateralize?
-            </Label>
-            <div className="grid grid-cols-7 gap-2">
-              <div className="col-span-4">
-                <div className="relative">
-                  <Input
-                    id="collateral-amount"
-                    name="collateral-amount"
-                    type="number"
-                    step="0.0001"
-                    max={selectedBalance ? Number(formatUnits(selectedBalance.balance.value, projectTokenDecimals)) : undefined}
-                    value={collateralAmount}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      
-                      // Allow empty input for clearing
-                      if (value === "") {
-                        setCollateralAmount("");
-                        return;
-                      }
-                      
-                      // Limit decimal places to 8 digits
-                      const decimalIndex = value.indexOf('.');
-                      if (decimalIndex !== -1 && value.length - decimalIndex - 1 > 8) {
-                        return; // Don't update if too many decimal places
-                      }
-                      
-                      const numValue = Number(value);
-                      const maxValue = selectedBalance ? Number(formatUnits(selectedBalance.balance.value, projectTokenDecimals)) : 0;
-                      
-                      // Only validate max if it's a valid number
-                      if (!isNaN(numValue)) {
-                        // Prevent entering more than available balance
-                        if (numValue > maxValue) {
-                          setCollateralAmount(maxValue.toFixed(6));
-                        } else {
-                          setCollateralAmount(value);
-                        }
-                      } else {
-                        // Allow partial input (like just a decimal point)
-                        setCollateralAmount(value);
-                      }
-                    }}
-                    placeholder={
-                      cashOutChainId && selectedBalance
-                        ? Number(formatUnits(selectedBalance.balance.value, projectTokenDecimals)).toFixed(8)
-                        : "Enter amount"
-                    }
-                    className="mt-2"
-                  />
-                  <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 z-10">
-                    <span className="text-zinc-500 sm:text-md">
-                      {tokenSymbol}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div className="col-span-3">
-                <Select 
-                  onValueChange={handleChainSelect} 
-                  value={cashOutChainId || ""}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select chain">
-                      {cashOutChainId && (
-                        <div className="flex items-center gap-2">
-                          <ChainLogo chainId={Number(cashOutChainId) as JBChainId} />
-                          <span>{JB_CHAINS[Number(cashOutChainId) as JBChainId].name}</span>
-                        </div>
-                      )}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {balances
-                      ?.filter((b) => b.balance.value > 0n)
-                      .map((balance) => {
-                        return (
-                          <SelectItem
-                            value={balance.chainId.toString()}
-                            key={balance.chainId}
-                          >
-                            <div className="flex items-center gap-2">
-                              <ChainLogo
-                                chainId={balance.chainId as JBChainId}
-                              />
-                              {
-                                JB_CHAINS[balance.chainId as JBChainId]
-                                  .name
-                              }
-                            </div>
-                          </SelectItem>
-                        );
-                      })}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <div className="grid grid-cols-7 gap-2">
-              <div className="col-span-4">
-                <div className="flex gap-1 mt-1 mb-2">
-                  {[10, 25, 50].map((pct) => (
-                    <button
-                      key={pct}
-                      type="button"
-                      onClick={() => {
-                        if (selectedBalance) {
-                          const value = Number(formatUnits(selectedBalance.balance.value, projectTokenDecimals)) * (pct / 100);
-                          setCollateralAmount(value.toFixed(6));
-                        }
-                      }}
-                      className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100"
-                    >
-                      {pct}%
-                    </button>
-                  ))}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (selectedBalance) {
-                        const maxValue = Number(formatUnits(selectedBalance.balance.value, projectTokenDecimals));
-                        setCollateralAmount(maxValue.toFixed(8));
-                      }
-                    }}
-                    className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100"
-                  >
-                    Max
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
+          <CollateralInput
+            label={`How much ${tokenSymbol} do you want to collateralize?`}
+            tokenSymbol={tokenSymbol}
+            collateralAmount={collateralAmount}
+            onCollateralChange={setCollateralAmount}
+            projectTokenDecimals={projectTokenDecimals}
+            balances={balances}
+            cashOutChainId={cashOutChainId}
+            onChainSelect={handleChainSelect}
+          />
 
           {/* --- Simulation state for loan preview, including reallocation --- */}
           {(() => {

--- a/src/app/[...slug]/components/UserTokenBalanceCard/CollateralInput.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/CollateralInput.tsx
@@ -1,0 +1,213 @@
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ChainLogo } from "@/components/ChainLogo";
+import { JB_CHAINS, JBChainId } from "juice-sdk-core";
+import { formatUnits } from "viem";
+import { useMemo } from "react";
+
+interface BalanceInfo {
+  chainId: number;
+  balance: {
+    value: bigint;
+    format: (decimals?: number) => string;
+  };
+}
+
+interface CollateralInputProps {
+  label: string;
+  tokenSymbol: string;
+  collateralAmount: string;
+  onCollateralChange: (value: string) => void;
+  projectTokenDecimals: number;
+  balances?: BalanceInfo[];
+  cashOutChainId?: string;
+  onChainSelect?: (chainId: string) => void;
+  showChainSelect?: boolean;
+  presetPercents?: number[];
+  includeZero?: boolean;
+  placeholder?: string;
+  maxValue?: string | number;
+}
+
+export function CollateralInput({
+  label,
+  tokenSymbol,
+  collateralAmount,
+  onCollateralChange,
+  projectTokenDecimals,
+  balances,
+  cashOutChainId,
+  onChainSelect,
+  showChainSelect = true,
+  presetPercents = [10, 25, 50],
+  includeZero = false,
+  placeholder,
+  maxValue,
+}: CollateralInputProps) {
+  const selectedBalance = useMemo(
+    () =>
+      balances && cashOutChainId
+        ? balances.find((b) => b.chainId === Number(cashOutChainId))
+        : undefined,
+    [balances, cashOutChainId]
+  );
+
+  const maxAmount = useMemo(() => {
+    if (typeof maxValue !== "undefined") return Number(maxValue);
+    if (selectedBalance)
+      return Number(
+        formatUnits(selectedBalance.balance.value, projectTokenDecimals)
+      );
+    return undefined;
+  }, [maxValue, selectedBalance, projectTokenDecimals]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    if (value === "") {
+      onCollateralChange("");
+      return;
+    }
+
+    const decimalIndex = value.indexOf(".");
+    if (decimalIndex !== -1 && value.length - decimalIndex - 1 > 8) {
+      return;
+    }
+
+    const numValue = Number(value);
+
+    if (!isNaN(numValue)) {
+      if (maxAmount !== undefined && numValue > maxAmount) {
+        onCollateralChange(maxAmount.toFixed(6));
+      } else {
+        onCollateralChange(value);
+      }
+    } else {
+      onCollateralChange(value);
+    }
+  };
+
+  const handlePercentClick = (pct: number) => {
+    if (maxAmount !== undefined) {
+      const value = maxAmount * (pct / 100);
+      onCollateralChange(value.toFixed(6));
+    }
+  };
+
+  const handleMaxClick = () => {
+    if (maxAmount !== undefined) {
+      onCollateralChange(maxAmount.toFixed(8));
+    }
+  };
+
+  return (
+    <div className="grid w-full gap-1.5">
+      <Label htmlFor="collateral-amount" className="text-zinc-900">
+        {label}
+      </Label>
+      <div className="grid grid-cols-7 gap-2">
+        <div className={showChainSelect ? "col-span-4" : "col-span-7"}>
+          <div className="relative">
+            <Input
+              id="collateral-amount"
+              name="collateral-amount"
+              type="number"
+              step="0.0001"
+              max={maxAmount}
+              value={collateralAmount}
+              onChange={handleChange}
+              placeholder={
+                placeholder ||
+                (maxAmount !== undefined
+                  ? maxAmount.toFixed(8)
+                  : "Enter amount")
+              }
+              className="mt-2"
+            />
+            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 z-10">
+              <span className="text-zinc-500 sm:text-md">{tokenSymbol}</span>
+            </div>
+          </div>
+        </div>
+        {showChainSelect && balances && onChainSelect && (
+          <div className="col-span-3">
+            <Select
+              onValueChange={onChainSelect}
+              value={cashOutChainId || ""}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select chain">
+                  {cashOutChainId && (
+                    <div className="flex items-center gap-2">
+                      <ChainLogo chainId={Number(cashOutChainId) as JBChainId} />
+                      <span>
+                        {
+                          JB_CHAINS[Number(cashOutChainId) as JBChainId].name
+                        }
+                      </span>
+                    </div>
+                  )}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {balances
+                  ?.filter((b) => b.balance.value > 0n)
+                  .map((balance) => (
+                    <SelectItem
+                      value={balance.chainId.toString()}
+                      key={balance.chainId}
+                    >
+                      <div className="flex items-center gap-2">
+                        <ChainLogo chainId={balance.chainId as JBChainId} />
+                        {JB_CHAINS[balance.chainId as JBChainId].name}
+                      </div>
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+      <div className="grid grid-cols-7 gap-2">
+        <div className={showChainSelect ? "col-span-4" : "col-span-7"}>
+          <div className="flex gap-1 mt-1 mb-2">
+            {includeZero && (
+              <button
+                type="button"
+                onClick={() => onCollateralChange("0")}
+                className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100"
+              >
+                0
+              </button>
+            )}
+            {presetPercents.map((pct) => (
+              <button
+                key={pct}
+                type="button"
+                onClick={() => handlePercentClick(pct)}
+                className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100"
+              >
+                {pct}%
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={handleMaxClick}
+              className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100"
+            >
+              Max
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/[...slug]/components/UserTokenBalanceCard/ReallocateDialog.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/ReallocateDialog.tsx
@@ -1,6 +1,4 @@
 import { useEffect } from "react";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
 import { formatUnits } from "viem";
 import { NATIVE_TOKEN_DECIMALS, JBChainId } from "juice-sdk-core";
 import {
@@ -18,6 +16,8 @@ import { ImportantInfo } from "./ImportantInfo";
 import { useBorrowDialogState } from "./hooks/useBorrowDialogState";
 import { SimulatedLoanCard } from "../SimulatedLoanCard";
 import type { Loan } from "@/types/loan";
+
+import { CollateralInput } from "./CollateralInput";
 
 import { BorrowState, borrowStatusMessages } from "./constants/borrowStatus";
 
@@ -171,85 +171,20 @@ export function ReallocateDialog({
               <div className="text-sm text-zinc-600 mb-2">
                 Head room to reallocate: {collateralToTransfer > 0 ? collateralToTransfer.toFixed(6) : "0.000000"} {tokenSymbol}
               </div>
-              <Label htmlFor="additional-collateral" className="block text-gray-700 text-sm font-bold mb-2">
-                How much additional {tokenSymbol} do you want to add as collateral for the new loan?
-              </Label>
-              <Input
-                id="additional-collateral"
-                type="number"
-                step="0.0001"
-                value={collateralAmount}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  
-                  // Allow empty input for clearing
-                  if (value === "") {
-                    setCollateralAmount("");
-                    return;
-                  }
-                  
-                  // Limit decimal places to 8 digits
-                  const decimalIndex = value.indexOf('.');
-                  if (decimalIndex !== -1 && value.length - decimalIndex - 1 > 8) {
-                    return; // Don't update if too many decimal places
-                  }
-                  
-                  const numValue = Number(value);
-                  
-                  // Only validate max if it's a valid number
-                  if (!isNaN(numValue)) {
-                    const maxValue = Number(borrowableAmountFormatted);
-                    
-                    // Prevent entering more than available balance
-                    if (numValue > maxValue) {
-                      setCollateralAmount(maxValue.toFixed(6));
-                    } else {
-                      setCollateralAmount(value);
-                    }
-                  } else {
-                    // Allow partial input (like just a decimal point)
-                    setCollateralAmount(value);
-                  }
-                }}
+              <CollateralInput
+                label={`How much additional ${tokenSymbol} do you want to add as collateral for the new loan?`}
+                tokenSymbol={tokenSymbol}
+                collateralAmount={collateralAmount}
+                onCollateralChange={setCollateralAmount}
+                projectTokenDecimals={projectTokenDecimals}
+                cashOutChainId={cashOutChainId}
+                balances={balances}
+                presetPercents={[10,25,50]}
+                includeZero
                 placeholder="Enter additional amount"
-                className="mb-2"
-                max={borrowableAmountFormatted}
+                maxValue={borrowableAmountFormatted}
+                showChainSelect={false}
               />
-              <div className="flex gap-1 mt-1 mb-2">
-                <div className="flex gap-1 mt-2 mb-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setCollateralAmount("0");
-                    }}
-                    className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100 w-16"
-                  >
-                    0
-                  </button>
-                  {[10, 25, 50].map((pct) => (
-                    <button
-                      key={pct}
-                      type="button"
-                      onClick={() => {
-                        const value = Number(borrowableAmountFormatted) * (pct / 100);
-                        setCollateralAmount(value.toString().replace(/\.?0+$/, ""));
-                      }}
-                      className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100 w-16"
-                    >
-                      {pct}%
-                    </button>
-                  ))}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setCollateralAmount(borrowableAmountFormatted);
-                    }}
-                    className="h-10 px-3 text-sm text-zinc-700 border border-zinc-300 rounded-md bg-white hover:bg-zinc-100 w-16"
-                  >
-                    Max
-                  </button>
-                </div>
-              </div>
             </div>
           )}
           


### PR DESCRIPTION
## Summary
- add reusable `CollateralInput` to manage chain selection, amount entry, and quick presets
- replace inline collateral sections in `BorrowDialog` and `ReallocateDialog`

## Testing
- `yarn lint` *(fails: ESLint warns about trailing spaces but command completes)*

------
https://chatgpt.com/codex/tasks/task_e_689387546f44832ebd873067ce74d286