### PR TITLE
refactor: centralize native token constant

### DIFF
--- a/src/app/[...slug]/components/PayCard/PayDialog.tsx
+++ b/src/app/[...slug]/components/PayCard/PayDialog.tsx
@@ -145,7 +145,7 @@ export function PayDialog({
 
     // Get the correct token for the selected chain
     const chainToken = getTokenForChain(selectedSucker.peerChainId);
-    const isNative = chainToken === "0x000000000000000000000000000000000000eeee";
+    const isNative = chainToken.toLowerCase() === NATIVE_TOKEN.toLowerCase();
 
     try {
       if (!isNative) {

--- a/src/app/[...slug]/components/PayCard/PayForm.tsx
+++ b/src/app/[...slug]/components/PayCard/PayForm.tsx
@@ -1,6 +1,6 @@
 import { useTokenA } from "@/hooks/useTokenA";
 import { FixedInt } from "fpnum";
-import { getTokenAToBQuote, getTokenBtoAQuote } from "juice-sdk-core";
+import { getTokenAToBQuote, getTokenBtoAQuote, NATIVE_TOKEN } from "juice-sdk-core";
 import {
   Field,
   Formik,
@@ -145,7 +145,7 @@ export function PayForm() {
               amountA={_amountA}
               amountB={_amountB}
               memo={memo}
-              paymentToken={(accountingContext?.project?.token as `0x${string}`) || "0x000000000000000000000000000000000000eeee"}
+              paymentToken={(accountingContext?.project?.token as `0x${string}`) || NATIVE_TOKEN}
               disabled={!amountA}
               onSuccess={() => {
                 resetForm();

--- a/src/app/[...slug]/components/UserTokenBalanceCard/BorrowDialog.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/BorrowDialog.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
 import { formatUnits } from "viem";
-import { NATIVE_TOKEN_DECIMALS, JBChainId } from "juice-sdk-core";
+import { NATIVE_TOKEN, NATIVE_TOKEN_DECIMALS, JBChainId } from "juice-sdk-core";
 import {
   Dialog,
   DialogContent,
@@ -81,9 +81,9 @@ export function BorrowDialog({
   // Get the correct token symbol for the selected chain
   const getTokenSymbolForChain = useCallback((targetChainId: number) => {
     const chainTokenConfig = getTokenConfigForChain(targetChainId);
-    
+
     // Get the actual token symbol from the bendystraw data
-    if (chainTokenConfig?.token?.toLowerCase() === "0x000000000000000000000000000000000000eeee") {
+    if (chainTokenConfig?.token?.toLowerCase() === NATIVE_TOKEN.toLowerCase()) {
       return "ETH";
     }
     

--- a/src/app/[...slug]/components/UserTokenBalanceCard/RedeemDialog.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/RedeemDialog.tsx
@@ -160,7 +160,7 @@ export function RedeemDialog({
   };
 
   const selectedChainToken = cashOutChainId ? getTokenForChain(Number(cashOutChainId)) : NATIVE_TOKEN;
-  const isNative = selectedChainToken === "0x000000000000000000000000000000000000eeee";
+  const isNative = selectedChainToken.toLowerCase() === NATIVE_TOKEN.toLowerCase();
 
   // Determine what token to receive from cashout
   // For ETH projects: receive ETH (NATIVE_TOKEN)

--- a/src/app/[...slug]/components/UserTokenBalanceCard/UserTokenBalanceCard.tsx
+++ b/src/app/[...slug]/components/UserTokenBalanceCard/UserTokenBalanceCard.tsx
@@ -61,7 +61,7 @@ export function UserTokenBalanceCard() {
 
     const allProjects = suckerGroupData.suckerGroup.projects.items;
     return allProjects.every(
-      project => project.token?.toLowerCase() === "0x000000000000000000000000000000000000eeee"
+      project => project.token?.toLowerCase() === NATIVE_TOKEN.toLowerCase()
     );
   })();
 

--- a/src/lib/tokenUtils.ts
+++ b/src/lib/tokenUtils.ts
@@ -1,4 +1,5 @@
 import { USDC_ADDRESSES } from "@/app/constants";
+import { NATIVE_TOKEN } from "juice-sdk-core";
 
 /**
  * Get token symbol from token address
@@ -7,7 +8,7 @@ import { USDC_ADDRESSES } from "@/app/constants";
  */
 export function getTokenSymbolFromAddress(tokenAddress: string): string {
   // Check for ETH (case insensitive)
-  if (tokenAddress?.toLowerCase() === "0x000000000000000000000000000000000000eeee") {
+  if (tokenAddress?.toLowerCase() === NATIVE_TOKEN.toLowerCase()) {
     return "ETH";
   }
   
@@ -38,7 +39,7 @@ export interface TokenConfig {
 export function getTokenConfigForChain(suckerGroupData: any, targetChainId: number): TokenConfig {
   if (!suckerGroupData?.suckerGroup?.projects?.items) {
     return {
-      token: "0x000000000000000000000000000000000000EEEe" as `0x${string}`,
+      token: NATIVE_TOKEN,
       currency: 1,
       decimals: 18
     };
@@ -57,7 +58,7 @@ export function getTokenConfigForChain(suckerGroupData: any, targetChainId: numb
   }
   
   return {
-    token: "0x000000000000000000000000000000000000EEEe" as `0x${string}`,
+    token: NATIVE_TOKEN,
     currency: 1,
     decimals: 18
   };


### PR DESCRIPTION
## Summary
- use `NATIVE_TOKEN` constant instead of hard-coded address
- update pay and token components to rely on shared constant

## Testing
- `yarn ts:compile` *(fails: The engine "node" is incompatible with this module. Expected version "22.x". Got "20.19.4" )*


------
https://chatgpt.com/codex/tasks/task_e_6893882eb364832e85808c3bb37ebc59