### PR TITLE
feat: add hook to read rev loans address

### DIFF
--- a/src/hooks/useReadRevDeployerLoansOf.ts
+++ b/src/hooks/useReadRevDeployerLoansOf.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { readContract } from "@wagmi/core";
+import { JBChainId } from "juice-sdk-react";
+import { revDeployerAddress } from "revnet-sdk";
+import { wagmiConfig } from "@/lib/wagmiConfig";
+
+const revDeployerLoansOfAbi = [
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "loansOf",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getRevLoansAddress({
+  revnetId,
+  chainId,
+}: {
+  revnetId: bigint;
+  chainId: JBChainId;
+}) {
+  return (await readContract(wagmiConfig, {
+    chainId,
+    address: revDeployerAddress[chainId],
+    abi: revDeployerLoansOfAbi,
+    functionName: "loansOf",
+    args: [revnetId],
+  })) as `0x${string}`;
+}
+
+export function useReadRevDeployerLoansOf({
+  revnetId,
+  chainId,
+  enabled = true,
+}: {
+  revnetId?: bigint;
+  chainId?: JBChainId;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: ["revDeployer", "loansOf", chainId, revnetId?.toString()],
+    queryFn: () =>
+      getRevLoansAddress({
+        revnetId: revnetId as bigint,
+        chainId: chainId as JBChainId,
+      }),
+    enabled: enabled && revnetId !== undefined && chainId !== undefined,
+  });
+}
+
+export type UseReadRevDeployerLoansOfResult = ReturnType<
+  typeof useReadRevDeployerLoansOf
+>;


### PR DESCRIPTION
## Summary
- add `getRevLoansAddress` util using `loansOf` on RevDeployer
- expose `useReadRevDeployerLoansOf` hook for querying loan contract address

## Testing
- `yarn --ignore-engines lint`
- `NODE_ENV=development NODE_OPTIONS=--max_old_space_size=4096 yarn --ignore-engines ts:compile` *(fails: Type 'number | undefined' is not assignable to type '1 | 10 | 8453 | 42161 | 84532 | 421614 | 11155111 | 11155420 | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_6893b97def5c832e993a418fcc0919b1