### PR TITLE
feat: allow paying with eth or usdc

### DIFF
--- a/src/app/[...slug]/components/PayCard/PayDialog.tsx
+++ b/src/app/[...slug]/components/PayCard/PayDialog.tsx
@@ -61,14 +61,24 @@ export function PayDialog({
   onSuccess?: () => void;
 }) {
   const { projectId } = useJBContractContext();
-  const primaryNativeTerminal = { data: "0xdb9644369c79c3633cde70d2df50d827d7dc7dbc" };
+  const primaryNativeTerminal = {
+    data: "0xdb9644369c79c3633cde70d2df50d827d7dc7dbc",
+  };
   const { address } = useAccount();
   const value = amountA.amount.value;
-  const { isError, error, writeContract, isPending: isWriteLoading, data } = useWriteJbMultiTerminalPay();
+  const {
+    isError,
+    error,
+    writeContract,
+    isPending: isWriteLoading,
+    data,
+  } = useWriteJbMultiTerminalPay();
   const chainId = useJBChainId();
   const { selectedSucker, setSelectedSucker } = useSelectedSucker();
   const txHash = data;
-  const { isLoading: isTxLoading, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
+  const { isLoading: isTxLoading, isSuccess } = useWaitForTransactionReceipt({
+    hash: txHash,
+  });
   const { toast } = useToast();
   const suckersQuery = useSuckers();
   const suckers = suckersQuery.data;
@@ -77,35 +87,56 @@ export function PayDialog({
   const [isApproving, setIsApproving] = useState(false);
 
   // Get the suckerGroupId from the current project
-  const { data: projectData } = useBendystrawQuery(ProjectDocument, {
-    chainId: Number(chainId),
-    projectId: Number(projectId),
-  }, {
-    enabled: !!chainId && !!projectId,
-  });
+  const { data: projectData } = useBendystrawQuery(
+    ProjectDocument,
+    {
+      chainId: Number(chainId),
+      projectId: Number(projectId),
+    },
+    {
+      enabled: !!chainId && !!projectId,
+    },
+  );
   const suckerGroupId = projectData?.project?.suckerGroupId;
 
   // Get all projects in the sucker group with their token data
-  const { data: suckerGroupData } = useBendystrawQuery(SuckerGroupDocument, {
-    id: suckerGroupId ?? "",
-  }, {
-    enabled: !!suckerGroupId,
-  });
+  const { data: suckerGroupData } = useBendystrawQuery(
+    SuckerGroupDocument,
+    {
+      id: suckerGroupId ?? "",
+    },
+    {
+      enabled: !!suckerGroupId,
+    },
+  );
 
   // Get the correct token address for the selected chain
   const getTokenForChain = (targetChainId: number) => {
+    if (paymentToken.toLowerCase() === NATIVE_TOKEN.toLowerCase()) {
+      return NATIVE_TOKEN;
+    }
+
+    const usdcAddressesLower = Object.values(USDC_ADDRESSES).map((addr) =>
+      addr.toLowerCase(),
+    );
+    if (
+      usdcAddressesLower.includes(paymentToken.toLowerCase() as `0x${string}`)
+    ) {
+      return USDC_ADDRESSES[targetChainId] || paymentToken;
+    }
+
     if (!suckerGroupData?.suckerGroup?.projects?.items) {
       return paymentToken; // fallback to original paymentToken
     }
-    
+
     const projectForChain = suckerGroupData.suckerGroup.projects.items.find(
-      project => project.chainId === targetChainId
+      (project) => project.chainId === targetChainId,
     );
-    
+
     if (projectForChain?.token) {
       return projectForChain.token as `0x${string}`;
     }
-    
+
     return paymentToken; // fallback to original paymentToken
   };
 
@@ -125,7 +156,9 @@ export function PayDialog({
       toast({
         variant: "destructive",
         title: "Error",
-        description: error.message || "An error occurred while processing your contribution",
+        description:
+          error.message ||
+          "An error occurred while processing your contribution",
       });
     }
   }, [isError, error, toast]);
@@ -143,7 +176,14 @@ export function PayDialog({
   const loading = isWriteLoading || isTxLoading || isApproving;
 
   const handlePay = async () => {
-    if (!primaryNativeTerminal?.data || !address || !selectedSucker || !walletClient || !publicClient) return;
+    if (
+      !primaryNativeTerminal?.data ||
+      !address ||
+      !selectedSucker ||
+      !walletClient ||
+      !publicClient
+    )
+      return;
 
     // Get the correct token for the selected chain
     const chainToken = getTokenForChain(selectedSucker.peerChainId);
@@ -187,7 +227,8 @@ export function PayDialog({
       });
     } catch (err) {
       setIsApproving(false);
-      const errMsg = err instanceof Error ? err.message : "Unknown error during payment";
+      const errMsg =
+        err instanceof Error ? err.message : "Unknown error during payment";
       console.error("Payment failed:", err);
       toast({
         variant: "destructive",
@@ -200,7 +241,10 @@ export function PayDialog({
   return (
     <Dialog open={disabled === true ? false : undefined}>
       <DialogTrigger asChild>
-        <Button disabled={disabled} className="w-full bg-teal-500 hover:bg-teal-600">
+        <Button
+          disabled={disabled}
+          className="w-full bg-teal-500 hover:bg-teal-600"
+        >
           Pay
         </Button>
       </DialogTrigger>
@@ -226,29 +270,45 @@ export function PayDialog({
                     )}
                     {memo && <Stat label="Memo">{memo}</Stat>}
                   </div>
-                  {isTxLoading ? <div>Transaction submitted, awaiting confirmation...</div> : null}
+                  {isTxLoading ? (
+                    <div>Transaction submitted, awaiting confirmation...</div>
+                  ) : null}
                 </>
               )}
             </div>
           </DialogDescription>
           {!isSuccess ? (
-            <div className="flex flex-row justify-between items-end">
+            <div className="flex flex-row items-end justify-between">
               {suckers && suckers.length > 1 ? (
-                <div className="flex flex-col mt-4">
-                  <div className="text-sm text-zinc-500">{amountB.symbol} is available on:</div>
+                <div className="mt-4 flex flex-col">
+                  <div className="text-sm text-zinc-500">
+                    {amountB.symbol} is available on:
+                  </div>
                   <Select
-                    onValueChange={(v) => setSelectedSucker(suckers[parseInt(v)])}
-                    value={selectedSucker ? String(suckers.indexOf(selectedSucker)) : undefined}
+                    onValueChange={(v) =>
+                      setSelectedSucker(suckers[parseInt(v)])
+                    }
+                    value={
+                      selectedSucker
+                        ? String(suckers.indexOf(selectedSucker))
+                        : undefined
+                    }
                   >
                     <SelectTrigger className="w-[200px]">
                       <SelectValue placeholder="Select chain" />
                     </SelectTrigger>
                     <SelectContent>
                       {suckers.map((s, index) => (
-                        <SelectItem key={s.peerChainId} value={String(index)} className="flex items-center gap-2">
+                        <SelectItem
+                          key={s.peerChainId}
+                          value={String(index)}
+                          className="flex items-center gap-2"
+                        >
                           <div className="flex items-center gap-2">
                             <ChainLogo chainId={s.peerChainId as JBChainId} />
-                            <span>{JB_CHAINS[s.peerChainId as JBChainId].name}</span>
+                            <span>
+                              {JB_CHAINS[s.peerChainId as JBChainId].name}
+                            </span>
                           </div>
                         </SelectItem>
                       ))}
@@ -257,17 +317,23 @@ export function PayDialog({
                 </div>
               ) : (
                 selectedSucker && (
-                  <div className="flex flex-col mt-4">
-                    <div className="text-xs text-slate-500">{amountB.symbol} is only on:</div>
-                    <div className="flex flex-row items-center gap-2 pl-3 min-w-fit pr-5 py-2 border ring-offset-white">
-                      <ChainLogo chainId={selectedSucker.peerChainId as JBChainId} />
+                  <div className="mt-4 flex flex-col">
+                    <div className="text-xs text-slate-500">
+                      {amountB.symbol} is only on:
+                    </div>
+                    <div className="flex min-w-fit flex-row items-center gap-2 border py-2 pl-3 pr-5 ring-offset-white">
+                      <ChainLogo
+                        chainId={selectedSucker.peerChainId as JBChainId}
+                      />
                       {JB_CHAINS[selectedSucker.peerChainId as JBChainId].name}
                     </div>
                   </div>
                 )
               )}
               <ButtonWithWallet
-                targetChainId={selectedSucker?.peerChainId as JBChainId | undefined}
+                targetChainId={
+                  selectedSucker?.peerChainId as JBChainId | undefined
+                }
                 loading={loading}
                 onClick={handlePay}
                 className="bg-teal-500 hover:bg-teal-600"

--- a/src/app/[...slug]/components/PayCard/PayInput.tsx
+++ b/src/app/[...slug]/components/PayCard/PayInput.tsx
@@ -7,43 +7,56 @@ export interface PayInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string;
   withPayOnSelect?: boolean;
-  currency?: string;
+  currency?: React.ReactNode;
   inputClassName?: string;
 }
 
 const PayInput = React.forwardRef<HTMLInputElement, PayInputProps>(
-  ({ className, inputClassName, label, type, currency, withPayOnSelect, ...props }, ref) => {
+  (
+    {
+      className,
+      inputClassName,
+      label,
+      type,
+      currency,
+      withPayOnSelect,
+      ...props
+    },
+    ref,
+  ) => {
     return (
       <div
         className={cn(
-          "flex h-30 px-4 py-4 w-full items-center justify-between shadow-sm focus-within:ring-1 focus-within:ring-inset focus-within:ring-zinc-500 bg-zinc-100",
-          className
+          "h-30 flex w-full items-center justify-between bg-zinc-100 px-4 py-4 shadow-sm focus-within:ring-1 focus-within:ring-inset focus-within:ring-zinc-500",
+          className,
         )}
       >
         <div className="flex flex-col">
           <div className="flex flex-row gap-1">
-            <label className="text-md text-black-700">
-              {label}
-            </label>
-            {withPayOnSelect && (
-              <PayOnSelect />
-            )}
+            <label className="text-md text-black-700">{label}</label>
+            {withPayOnSelect && <PayOnSelect />}
           </div>
           <input
             type={type}
             className={cn(
-              "border-0 bg-transparent pl-0 pr-3 pt-1 pb-0 text-zinc-900 text-2xl w-full placeholder:text-zinc-400 focus:ring-0 sm:leading-6",
-              inputClassName
+              "w-full border-0 bg-transparent pb-0 pl-0 pr-3 pt-1 text-2xl text-zinc-900 placeholder:text-zinc-400 focus:ring-0 sm:leading-6",
+              inputClassName,
             )}
             ref={ref}
             placeholder="0.00"
             {...props}
           />
         </div>
-        <span className="text-right select-none text-lg">{currency}</span>
+        {currency ? (
+          typeof currency === "string" ? (
+            <span className="select-none text-right text-lg">{currency}</span>
+          ) : (
+            <div className="text-right text-lg">{currency}</div>
+          )
+        ) : null}
       </div>
     );
-  }
+  },
 );
 PayInput.displayName = "PayInput";
 

--- a/src/app/[...slug]/components/PayCard/SelectPaymentToken.tsx
+++ b/src/app/[...slug]/components/PayCard/SelectPaymentToken.tsx
@@ -1,0 +1,44 @@
+import { PaymentToken } from "@/hooks/useAvailablePaymentTokens";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function SelectPaymentToken({
+  tokens,
+  value,
+  onChange,
+}: {
+  tokens: PaymentToken[];
+  value: PaymentToken;
+  onChange: (token: PaymentToken) => void;
+}) {
+  if (!tokens.length) return null;
+  if (tokens.length === 1) {
+    return <span className="select-none">{value.symbol}</span>;
+  }
+
+  return (
+    <Select
+      value={value.address}
+      onValueChange={(addr) => {
+        const token = tokens.find((t) => t.address === (addr as `0x${string}`));
+        if (token) onChange(token);
+      }}
+    >
+      <SelectTrigger className="h-auto border-none bg-transparent p-0 text-right text-lg">
+        <SelectValue placeholder={value.symbol} />
+      </SelectTrigger>
+      <SelectContent>
+        {tokens.map((token) => (
+          <SelectItem key={token.address} value={token.address}>
+            {token.symbol}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/hooks/useAvailablePaymentTokens.ts
+++ b/src/hooks/useAvailablePaymentTokens.ts
@@ -1,0 +1,35 @@
+import { useJBChainId } from "juice-sdk-react";
+import { NATIVE_TOKEN, NATIVE_TOKEN_DECIMALS } from "juice-sdk-core";
+import { USDC_ADDRESSES, USDC_DECIMALS } from "@/app/constants";
+
+export type PaymentToken = {
+  symbol: string;
+  address: `0x${string}`;
+  decimals: number;
+  isNative: boolean;
+};
+
+export function useAvailablePaymentTokens(): PaymentToken[] {
+  const chainId = useJBChainId();
+
+  const tokens: PaymentToken[] = [
+    {
+      symbol: "ETH",
+      address: NATIVE_TOKEN,
+      decimals: NATIVE_TOKEN_DECIMALS,
+      isNative: true,
+    },
+  ];
+
+  const usdcAddress = chainId ? USDC_ADDRESSES[Number(chainId)] : undefined;
+  if (usdcAddress) {
+    tokens.push({
+      symbol: "USDC",
+      address: usdcAddress,
+      decimals: USDC_DECIMALS,
+      isNative: false,
+    });
+  }
+
+  return tokens;
+}


### PR DESCRIPTION
## Summary
- add hook to provide ETH and USDC payment options based on chain
- integrate selectable payment token into Pay form and dialog
- support rendering custom currency nodes in Pay inputs

## Testing
- `yarn --ignore-engines lint`
- `yarn --ignore-engines ts:compile` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6893d8dc4df0832ea92cafc640d29e1f