### PR TITLE
fix: prevent payment token effect loop

### DIFF
--- a/src/app/[...slug]/components/PayCard/PayForm.tsx
+++ b/src/app/[...slug]/components/PayCard/PayForm.tsx
@@ -25,8 +25,10 @@ export function PayForm() {
     const defaultToken =
       availableTokens.find((t) => t.symbol === defaultSymbol) ||
       availableTokens[0];
-    setSelectedToken(defaultToken);
-  }, [baseTokenInfo, availableTokens]);
+    if (defaultToken && selectedToken.symbol !== defaultToken.symbol) {
+      setSelectedToken(defaultToken);
+    }
+  }, [baseTokenInfo, availableTokens, selectedToken.symbol]);
 
   const { token } = useJBTokenContext();
   const [memo, setMemo] = useState<string>();

--- a/src/hooks/useAvailablePaymentTokens.ts
+++ b/src/hooks/useAvailablePaymentTokens.ts
@@ -1,6 +1,7 @@
 import { useJBChainId } from "juice-sdk-react";
 import { NATIVE_TOKEN, NATIVE_TOKEN_DECIMALS } from "juice-sdk-core";
 import { USDC_ADDRESSES, USDC_DECIMALS } from "@/app/constants";
+import { useMemo } from "react";
 
 export type PaymentToken = {
   symbol: string;
@@ -12,24 +13,26 @@ export type PaymentToken = {
 export function useAvailablePaymentTokens(): PaymentToken[] {
   const chainId = useJBChainId();
 
-  const tokens: PaymentToken[] = [
-    {
-      symbol: "ETH",
-      address: NATIVE_TOKEN,
-      decimals: NATIVE_TOKEN_DECIMALS,
-      isNative: true,
-    },
-  ];
+  return useMemo(() => {
+    const tokens: PaymentToken[] = [
+      {
+        symbol: "ETH",
+        address: NATIVE_TOKEN,
+        decimals: NATIVE_TOKEN_DECIMALS,
+        isNative: true,
+      },
+    ];
 
-  const usdcAddress = chainId ? USDC_ADDRESSES[Number(chainId)] : undefined;
-  if (usdcAddress) {
-    tokens.push({
-      symbol: "USDC",
-      address: usdcAddress,
-      decimals: USDC_DECIMALS,
-      isNative: false,
-    });
-  }
+    const usdcAddress = chainId ? USDC_ADDRESSES[Number(chainId)] : undefined;
+    if (usdcAddress) {
+      tokens.push({
+        symbol: "USDC",
+        address: usdcAddress,
+        decimals: USDC_DECIMALS,
+        isNative: false,
+      });
+    }
 
-  return tokens;
+    return tokens;
+  }, [chainId]);
 }


### PR DESCRIPTION
## Summary
- memoize available payment tokens so token list doesn't change every render
- avoid resetting selected payment token when the default hasn't changed

## Testing
- `yarn --ignore-engines lint`
- `yarn --ignore-engines ts:compile` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6893dfad3270832ea3b967fc98c1a712