### PR TITLE
feat: show value across chains

### DIFF
--- a/src/app/[...slug]/components/NetworkDashboard/sections/HoldersSection/YouSection.tsx
+++ b/src/app/[...slug]/components/NetworkDashboard/sections/HoldersSection/YouSection.tsx
@@ -1,4 +1,3 @@
-import { NativeTokenValue } from "@/components/NativeTokenValue";
 import {
   Tooltip,
   TooltipContent,
@@ -83,7 +82,6 @@ export function YouSection({ totalSupply }: { totalSupply: bigint }) {
             {formatPortion(totalBalance, totalSupply)}%
           </dd>
         </div>
-        {/* comment out for now until fixed
         <div className="sm:col-span-1 sm:px-0 grid grid-cols-2 sm:grid-cols-4">
           <dt className="text-md font-medium leading-6 text-zinc-900">
             Value Across Chains
@@ -146,7 +144,6 @@ export function YouSection({ totalSupply }: { totalSupply: bigint }) {
             </Tooltip>
           </dd>
         </div>
-        */}
         {/* comment out for now until sucker of bendystraw
         <div className="sm:col-span-1 sm:px-0 grid grid-cols-2 sm:grid-cols-4">
           <dt className="text-md font-medium leading-6 text-zinc-900">


### PR DESCRIPTION
## Summary
- display user's value across chains under ownership information

## Testing
- `yarn lint src/app/[...slug]/components/NetworkDashboard/sections/HoldersSection/YouSection.tsx` *(fails: The engine "node" is incompatible with this module. Expected version "22.x". Got "20.19.4"; ESLint must be installed)*
- `yarn ts:compile` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed7bee28832eb9aa96e726c86ecf